### PR TITLE
new xfloat def for figures and colors packages

### DIFF
--- a/uicthesi.cls
+++ b/uicthesi.cls
@@ -1295,21 +1295,44 @@
 %
 % Reset baselinestretch within footnotes and floats.
 %    \begin{macrocode}
+
+%%
+%% Workaround for figures and color packages conflicts
+%% Taken from https://latex.org/forum/viewtopic.php?f=45&t=4766&start=10#p33170
+%%
+
+\makeatletter
+\let\my@xfloat\@xfloat
+\makeatother
+
+\makeatletter
 \def\@xfloat#1[#2]{
-   \ifhmode \@bsphack\@floatpenalty -\@Mii
-   \else \@floatpenalty-\@Miii\fi
-   \def\@captype{#1}
-   \ifinner
-      \@parmoderr\@floatpenalty\z@
-   \else\@next\@currbox\@freelist{\@tempcnta\csname ftype@#1\endcsname
-      \multiply\@tempcnta\@xxxii\advance\@tempcnta\sixt@@n
-         \@tfor \@tempa :=#2\do
-                     {\if\@tempa h\advance\@tempcnta \@ne\fi
-                      \if\@tempa t\advance\@tempcnta \tw@\fi
-                      \if\@tempa b\advance\@tempcnta 4\relax\fi
-                      \if\@tempa p\advance\@tempcnta 8\relax\fi}
-         \global\count\@currbox\@tempcnta}\@fltovf\fi
-   \global\setbox\@currbox\vbox\bgroup
-   \def\baselinestretch{1}\small\normalsize
-   \hsize\columnwidth \@parboxrestore}
+	\my@xfloat#1[#2]%
+	\def\baselinestretch{1}%
+	\@normalsize \normalsize
+}
+\makeatother
+
+%%
+%% Previous code
+%%
+
+%\def\@xfloat#1[#2]{
+%   \ifhmode \@bsphack\@floatpenalty -\@Mii
+%   \else \@floatpenalty-\@Miii\fi
+%   \def\@captype{#1}
+%   \ifinner
+%      \@parmoderr\@floatpenalty\z@
+%   \else\@next\@currbox\@freelist{\@tempcnta\csname ftype@#1\endcsname
+%      \multiply\@tempcnta\@xxxii\advance\@tempcnta\sixt@@n
+%         \@tfor \@tempa :=#2\do
+%                     {\if\@tempa h\advance\@tempcnta \@ne\fi
+%                      \if\@tempa t\advance\@tempcnta \tw@\fi
+%                      \if\@tempa b\advance\@tempcnta 4\relax\fi
+%                      \if\@tempa p\advance\@tempcnta 8\relax\fi}
+%         \global\count\@currbox\@tempcnta}\@fltovf\fi
+%   \global\setbox\@currbox\vbox\bgroup
+%   \def\baselinestretch{1}\small\normalsize
+%   \hsize\columnwidth \@parboxrestore}
+
 %    \end{macrocode}


### PR DESCRIPTION
If packages like color, xcolor, tikz are used, and thesis contains figure environment, compiling throws "too many }'s" error. Changing the definition of \@xfloat at the end of uicthesi.cls  with the approach here fixes the issue:

https://latex.org/forum/viewtopic.php?f=45&t=4766&start=10#p33170