### PR TITLE
Table fix

### DIFF
--- a/sections/1_sample_chapter/2_turmoil.tex
+++ b/sections/1_sample_chapter/2_turmoil.tex
@@ -2,6 +2,7 @@
 \label{intro:turmoil}
 
 \input{tables/ramones_stats}
+\input{tables/tour_stats}
 
 However, things were always smiles-times for The Ramones.  As \ref{table:stats}
 shows, there were lots of members in the band.  Many of them were kind crummy,

--- a/tables/tour_stats.tex
+++ b/tables/tour_stats.tex
@@ -1,0 +1,24 @@
+\begin{table}[t]
+    \centering
+    \resizebox{.7\textwidth}{!}{
+      \begin{tabular}{ l | r r r }
+        \toprule
+          Tour Year &
+          Cities Visited &
+          Total Shows &
+          Average Attendance \\
+        \midrule
+        1976 & 20  & 50 & 3,200 \\
+        1978 & 32  & 68 & 4,500 \\
+        1980 & 25  & 60 & 4,000 \\
+        1983 & 40  & 95 & 5,200 \\
+        1986 & 35  & 85 & 4,700 \\
+        1989 & 30  & 78 & 3,900 \\
+        1991 & 22  & 55 & 4,100 \\
+        1994 & 18  & 48 & 4,500 \\
+        \bottomrule
+      \end{tabular}
+    }
+    \caption{Table showing tour statistics for the Ramones.}
+    \label{table:tour_stats}
+\end{table}  

--- a/thesis.tex
+++ b/thesis.tex
@@ -30,7 +30,7 @@ Danizg, New York University}
 \input{sections/other/_1_dedication}
 \input{sections/other/_2_acknowledgement}
 \input{sections/other/_3_contribution_of_authors}
-\setcounter{table}{0}	# fixes https://github.com/bitslab/uic-cs-thesis-template/issues/3#issuecomment-2455616743
+\setcounter{table}{0}	# fixes #3 (https://github.com/bitslab/uic-cs-thesis-template/issues/3#issuecomment-2455616743)
 \tableofcontents
 \listoftables
 \listoffigures

--- a/thesis.tex
+++ b/thesis.tex
@@ -30,7 +30,7 @@ Danizg, New York University}
 \input{sections/other/_1_dedication}
 \input{sections/other/_2_acknowledgement}
 \input{sections/other/_3_contribution_of_authors}
-\setcounter{table}{-1}
+\setcounter{table}{0}
 \tableofcontents
 \listoftables
 \listoffigures

--- a/thesis.tex
+++ b/thesis.tex
@@ -30,7 +30,7 @@ Danizg, New York University}
 \input{sections/other/_1_dedication}
 \input{sections/other/_2_acknowledgement}
 \input{sections/other/_3_contribution_of_authors}
-\setcounter{table}{0}
+\setcounter{table}{0}	# fixes https://github.com/bitslab/uic-cs-thesis-template/issues/3#issuecomment-2455616743
 \tableofcontents
 \listoftables
 \listoffigures


### PR DESCRIPTION
## Bug Fix: Correct Table Numbering in List of Tables and/or Captions

### Fixes issue: #3  

### Issue Description
In the main document (`thesis.tex`), the table counter is set to `-1` before generating the Table of Contents (TOC) using:
```latex
\setcounter{table}{-1}  % Original line in thesis.tex
\tableofcontents
```

This setup leads to incorrect numbering of only the _first_ table:
- **Overleaf (pdfLaTeX 2024):** The first table lacks a number in both the table caption and list of tables entry.
- **Locally compiled PDFs:** The TOC entry for the first table is unnumbered.

This bug disrupts table numbering consistency, especially with multiple tables.

### Solution/Workaround
Changing the table counter initialization to 0 resolves the issue across both Overleaf and local compilations:
```latex
\setcounter{table}{0}  % Original line in thesis.tex
\tableofcontents
```
I have also added a new dummy table just so this issue is apparent should it crop up in the future.