### PR TITLE
Updating glossaries terminology

### DIFF
--- a/sections/other/__preamble.tex
+++ b/sections/other/__preamble.tex
@@ -26,9 +26,9 @@
      {\end{longtable}}%
   \renewcommand*{\glossaryheader}{}%
   \renewcommand*{\glsgroupheading}[1]{}%
-  \renewcommand*{\glossaryentryfield}[5]{%
+  \renewcommand*{\glossentry}[5]{%
     \glstarget{##1}{##2} & ##3\glspostdescription\space ##5\\}%
-  \renewcommand*{\glossarysubentryfield}[6]{%
+  \renewcommand*{\subglossentry}[6]{%
      & \glstarget{##2}{\strut}##4\glspostdescription\space ##6\\}%
   %\renewcommand*{\glsgroupskip}{ & \\}%
 }

--- a/uicthesi.cls
+++ b/uicthesi.cls
@@ -61,7 +61,7 @@
 
 % First, let us announce ourselves.
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{uicthesi}[1996/01/31 v1.2 University of Illinois at Chicago Thesis Class]
+\ProvidesClass{uicthesi}[1996/01/31 v1.2 University of Illinois Chicago Thesis Class]
 %
 % BEGIN OPTIONS
 %
@@ -177,7 +177,7 @@
                Submitted in partial fulfillment of the requirements\\
                for the degree of \@degree\\
                in the Graduate College of the\\
-               University of Illinois at Chicago, \@date
+               University of Illinois Chicago, \@date
                \vskip 3\baselineskip
                Chicago, Illinois
             \end{center}}


### PR DESCRIPTION
"glossaryentryfield" and "glossarysubentryfield" have been "glossentry" and "subglossentry" since glossaries 4.5